### PR TITLE
Fix form field handling, session key config, and helper URL bug

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,12 +52,40 @@ $url = $this->Comments->url('Posts', $post->id);
 
 // Use in a form
 echo $this->Form->create(null, ['url' => $this->Comments->url('Posts', $post->id)]);
-echo $this->Form->control('comment');
+echo $this->Form->control('comment'); // or 'content' - both are accepted
 echo $this->Form->button(__('Submit'));
 echo $this->Form->end();
 ```
 
 The alias passed to `url()` must match a key in your `controllerModels` configuration.
+
+The form field can be named either `comment` or `content` - both are accepted.
+
+### Session Configuration (CakeDC/Users, Authentication Plugin)
+
+By default, the plugin looks for user identity under `Auth.User` session key (legacy CakePHP Auth).
+If you're using CakeDC/Users or the modern CakePHP Authentication plugin, the identity is stored under `Auth` directly.
+
+Configure the session key in your `config/app.php`:
+
+```php
+'Comments' => [
+    'sessionKey' => 'Auth', // For CakeDC/Users or Authentication plugin
+    // 'sessionKey' => 'Auth.User', // Default (legacy Auth)
+    'userIdField' => 'id', // The field in the user identity containing the user ID
+    'controllerModels' => [
+        // ...
+    ],
+],
+```
+
+If using the CommentComponent, you can also configure it per-controller:
+
+```php
+$this->loadComponent('Comments.Comment', [
+    'sessionKey' => 'Auth',
+]);
+```
 
 ## Admin Backend
 Go to `/admin/comments`.

--- a/src/Controller/CommentsController.php
+++ b/src/Controller/CommentsController.php
@@ -47,7 +47,7 @@ class CommentsController extends AppController {
 		$data['model'] = $model;
 		$data['foreign_key'] = $entity->get('id');
 		$data['user_id'] = $this->userId();
-		$data['content'] = $data['comment'] ?? null;
+		$data['content'] = $data['comment'] ?? $data['content'] ?? null;
 
 		$result = $this->Comments->add($data);
 		if ($result->isNew()) {
@@ -71,7 +71,9 @@ class CommentsController extends AppController {
 			return $this->Auth->user('id');
 		}
 
-		return $this->getRequest()->getSession()->read('Auth.User.' . $userIdField);
+		$sessionKey = Configure::read('Comments.sessionKey') ?? 'Auth.User';
+
+		return $this->getRequest()->getSession()->read($sessionKey . '.' . $userIdField);
 	}
 
 	/**

--- a/src/Controller/Component/CommentComponent.php
+++ b/src/Controller/Component/CommentComponent.php
@@ -60,6 +60,7 @@ class CommentComponent extends Component {
 		'on' => 'beforeRender',
 		'userModelClass' => 'Users',
 		'userIdField' => 'id',
+		'sessionKey' => null, // Defaults to 'Auth.User', use 'Auth' for CakeDC/Users
 		'allowAnonymous' => false,
 		'useEntity' => true,
 		'viewVariable' => null,
@@ -352,7 +353,8 @@ class CommentComponent extends Component {
 		} elseif (!$userId && $this->Controller->components()->has('Auth')) {
 			$userId = $this->Controller->Auth->user($this->getConfig('userIdField'));
 		} elseif (!$userId) {
-			$userId = $this->Controller->getRequest()->getSession()->read('Auth.User.' . $this->getConfig('userIdField'));
+			$sessionKey = $this->getConfig('sessionKey') ?? Configure::read('Comments.sessionKey') ?? 'Auth.User';
+			$userId = $this->Controller->getRequest()->getSession()->read($sessionKey . '.' . $this->getConfig('userIdField'));
 		}
 
 		return $userId;

--- a/src/Model/Behavior/CommentableBehavior.php
+++ b/src/Model/Behavior/CommentableBehavior.php
@@ -136,7 +136,7 @@ class CommentableBehavior extends Behavior {
 		}
 
 		$data = $options['data'];
-		$data['content'] = $data['comment'] ?? null;
+		$data['content'] = $data['comment'] ?? $data['content'] ?? null;
 		if ($data) {
 			$data['user_id'] = $options['userId'];
 			$data['model'] = $options['model'];

--- a/src/View/Helper/CommentsHelper.php
+++ b/src/View/Helper/CommentsHelper.php
@@ -32,7 +32,7 @@ class CommentsHelper extends Helper {
 			throw new NotFoundException('Invalid alias');
 		}
 
-		return $this->Url->build(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'add', $model, $id]);
+		return $this->Url->build(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'add', $alias, $id]);
 	}
 
 }

--- a/tests/TestCase/Controller/CommentsControllerTest.php
+++ b/tests/TestCase/Controller/CommentsControllerTest.php
@@ -28,7 +28,7 @@ class CommentsControllerTest extends TestCase {
 	];
 
 	/**
-	 * Test add method
+	 * Test add method with 'comment' field name
 	 *
 	 * @uses \Comments\Controller\CommentsController::add()
 	 *
@@ -46,6 +46,34 @@ class CommentsControllerTest extends TestCase {
 		$this->post(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'add', 'Posts', 1], $data);
 
 		$this->assertRedirect(['action' => 'index']);
+
+		Configure::delete('Comments.controllerModels');
+	}
+
+	/**
+	 * Test add method with 'content' field name (alternative)
+	 *
+	 * @uses \Comments\Controller\CommentsController::add()
+	 *
+	 * @return void
+	 */
+	public function testAddWithContentField(): void {
+		$this->disableErrorHandlerMiddleware();
+
+		Configure::write('Comments.controllerModels.Posts', 'Posts');
+
+		$data = [
+			'content' => 'This is a test comment using content field',
+		];
+
+		$this->post(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'add', 'Posts', 1], $data);
+
+		$this->assertRedirect(['action' => 'index']);
+
+		$comment = $this->fetchTable('Comments.Comments')->find()
+			->where(['content' => 'This is a test comment using content field'])
+			->first();
+		$this->assertNotNull($comment);
 
 		Configure::delete('Comments.controllerModels');
 	}

--- a/tests/TestCase/View/Helper/CommentsHelperTest.php
+++ b/tests/TestCase/View/Helper/CommentsHelperTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace Comments\Test\TestCase\View\Helper;
+
+use Cake\Core\Configure;
+use Cake\Http\Exception\NotFoundException;
+use Cake\Routing\Route\DashedRoute;
+use Cake\Routing\RouteBuilder;
+use Cake\Routing\Router;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+use Comments\View\Helper\CommentsHelper;
+
+/**
+ * Comments\View\Helper\CommentsHelper Test Case
+ */
+class CommentsHelperTest extends TestCase {
+
+	/**
+	 * @var \Comments\View\Helper\CommentsHelper
+	 */
+	protected CommentsHelper $helper;
+
+	/**
+	 * setUp method
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		Router::createRouteBuilder('/')->scope('/', function (RouteBuilder $routes) {
+			$routes->setRouteClass(DashedRoute::class);
+			$routes->plugin('Comments', ['path' => '/comments'], function (RouteBuilder $builder) {
+				$builder->fallbacks();
+			});
+		});
+
+		$view = new View();
+		$this->helper = new CommentsHelper($view);
+	}
+
+	/**
+	 * tearDown method
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		unset($this->helper);
+		Configure::delete('Comments.controllerModels');
+		Router::reload();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test url method generates correct URL with alias
+	 *
+	 * @return void
+	 */
+	public function testUrl(): void {
+		Configure::write('Comments.controllerModels.Posts', 'Posts');
+
+		$result = $this->helper->url('Posts', 123);
+
+		$this->assertStringContainsString('/comments/comments/add/Posts/123', $result);
+	}
+
+	/**
+	 * Test url method with plugin model
+	 *
+	 * @return void
+	 */
+	public function testUrlWithPluginModel(): void {
+		Configure::write('Comments.controllerModels.Articles', 'Blog.Articles');
+
+		$result = $this->helper->url('Articles', 456);
+
+		// Should use alias 'Articles' in URL, not 'Blog.Articles'
+		$this->assertStringContainsString('/comments/comments/add/Articles/456', $result);
+		$this->assertStringNotContainsString('Blog.Articles', $result);
+	}
+
+	/**
+	 * Test url method throws exception for invalid alias
+	 *
+	 * @return void
+	 */
+	public function testUrlInvalidAlias(): void {
+		$this->expectException(NotFoundException::class);
+
+		$this->helper->url('NonExistent', 1);
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes three issues reported/discovered:

- **Form field name bug**: The code only accepted `comment` as form field name. If users named their field `content` (the actual DB column), it was overwritten with `null`. Now accepts both field names.

- **Session key incompatibility**: Hardcoded `Auth.User` session key doesn't work with CakeDC/Users or the modern CakePHP Authentication plugin which use `Auth` directly. Added configurable `Comments.sessionKey` option.

- **CommentsHelper URL bug**: The helper was passing `$model` (e.g., `'Blog.Articles'`) instead of `$alias` (e.g., `'Articles'`) to the URL, breaking the controller lookup.

## Configuration

For CakeDC/Users or Authentication plugin users, add to `config/app.php`:

```php
'Comments' => [
    'sessionKey' => 'Auth', // Instead of default 'Auth.User'
],
```

## Test plan

- [ ] Verify comments can be submitted using `Form->control('content')`
- [ ] Verify comments can be submitted using `Form->control('comment')`
- [ ] Verify user_id is correctly captured with CakeDC/Users when `sessionKey` is set to `'Auth'`
- [ ] Verify CommentsHelper generates correct URLs matching controllerModels aliases