### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/Comments/edit.php
+++ b/templates/Admin/Comments/edit.php
@@ -5,15 +5,22 @@
  * @var string[]|\Cake\Collection\CollectionInterface $parentComments
  * @var string[]|\Cake\Collection\CollectionInterface $users
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <div class="row">
     <aside class="column large-3 medium-4 columns col-sm-4 col-12">
         <ul class="side-nav nav nav-pills flex-column">
             <li class="nav-item heading"><?= __('Actions') ?></li>
-            <li class="nav-item"><?= $this->Form->postLink(
+            <li class="nav-item"><?= $this->Form->postButton(
                 __('Delete'),
                 ['action' => 'delete', $comment->id],
-                ['confirm' => __('Are you sure you want to delete # {0}?', $comment->id), 'class' => 'side-nav-item']
+                [
+                    'class' => 'side-nav-item btn btn-link text-start w-100',
+                    'form' => [
+                        'class' => 'd-inline',
+                        'data-confirm-message' => __('Are you sure you want to delete # {0}?', $comment->id),
+                    ],
+                ]
                 ) ?></li>
             <li class="nav-item"><?= $this->Html->link(__('List Comments'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
         </ul>
@@ -40,3 +47,12 @@
         </div>
     </div>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+        if (!confirm(this.dataset.confirmMessage)) {
+            e.preventDefault();
+        }
+    });
+});
+</script>

--- a/templates/Admin/Comments/index.php
+++ b/templates/Admin/Comments/index.php
@@ -3,6 +3,7 @@
  * @var \App\View\AppView $this
  * @var iterable<\Comments\Model\Entity\Comment> $comments
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills flex-column">
@@ -52,7 +53,14 @@
                     <td class="actions">
                         <?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $comment->id], ['escapeTitle' => false]); ?>
                         <?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $comment->id], ['escapeTitle' => false]); ?>
-                        <?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $comment->id], ['escapeTitle' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $comment->id)]); ?>
+                        <?php echo $this->Form->postButton($this->Icon->render('delete'), ['action' => 'delete', $comment->id], [
+                            'escapeTitle' => false,
+                            'class' => 'btn btn-link p-0 align-baseline',
+                            'form' => [
+                                'class' => 'd-inline',
+                                'data-confirm-message' => __('Are you sure you want to delete # {0}?', $comment->id),
+                            ],
+                        ]); ?>
                     </td>
                 </tr>
                 <?php endforeach; ?>
@@ -62,3 +70,12 @@
 
     <?php echo $this->element('Tools.pagination'); ?>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+        if (!confirm(this.dataset.confirmMessage)) {
+            e.preventDefault();
+        }
+    });
+});
+</script>

--- a/templates/Admin/Comments/view.php
+++ b/templates/Admin/Comments/view.php
@@ -3,13 +3,20 @@
  * @var \App\View\AppView $this
  * @var \Comments\Model\Entity\Comment $comment
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <div class="row">
     <aside class="column actions large-3 medium-4 col-sm-4 col-xs-12">
         <ul class="side-nav nav nav-pills flex-column">
             <li class="nav-item heading"><?= __('Actions') ?></li>
             <li class="nav-item"><?= $this->Html->link(__('Edit {0}', __('Comment')), ['action' => 'edit', $comment->id], ['class' => 'side-nav-item']) ?></li>
-            <li class="nav-item"><?= $this->Form->postLink(__('Delete {0}', __('Comment')), ['action' => 'delete', $comment->id], ['confirm' => __('Are you sure you want to delete # {0}?', $comment->id), 'class' => 'side-nav-item']) ?></li>
+            <li class="nav-item"><?= $this->Form->postButton(__('Delete {0}', __('Comment')), ['action' => 'delete', $comment->id], [
+                'class' => 'side-nav-item btn btn-link text-start w-100',
+                'form' => [
+                    'class' => 'd-inline',
+                    'data-confirm-message' => __('Are you sure you want to delete # {0}?', $comment->id),
+                ],
+            ]) ?></li>
             <li class="nav-item"><?= $this->Html->link(__('List {0}', __('Comments')), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
         </ul>
     </aside>
@@ -88,7 +95,14 @@
                             <td class="actions">
                                 <?php echo $this->Html->link($this->Icon->render('view'), ['controller' => 'Comments', 'action' => 'view', $childComments->id], ['escapeTitle' => false]); ?>
                                 <?php echo $this->Html->link($this->Icon->render('edit'), ['controller' => 'Comments', 'action' => 'edit', $childComments->id], ['escapeTitle' => false]); ?>
-                                <?php echo $this->Form->postLink($this->Icon->render('delete'), ['controller' => 'Comments', 'action' => 'delete', $childComments->id], ['escapeTitle' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $childComments->id)]); ?>
+                                <?php echo $this->Form->postButton($this->Icon->render('delete'), ['controller' => 'Comments', 'action' => 'delete', $childComments->id], [
+                                    'escapeTitle' => false,
+                                    'class' => 'btn btn-link p-0 align-baseline',
+                                    'form' => [
+                                        'class' => 'd-inline',
+                                        'data-confirm-message' => __('Are you sure you want to delete # {0}?', $childComments->id),
+                                    ],
+                                ]); ?>
                             </td>
                         </tr>
                         <?php endforeach; ?>
@@ -99,3 +113,12 @@
         </div>
     </div>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+        if (!confirm(this.dataset.confirmMessage)) {
+            e.preventDefault();
+        }
+    });
+});
+</script>


### PR DESCRIPTION
## Summary

- Replace 4 `Form->postLink` + `confirm` calls with `Form->postButton` + `data-confirm-message`.
- Add nonce-aware inline `<script>` blocks that delegate confirmation handling via `form[data-confirm-message]`.

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` and inline event handlers (`onclick=`, etc.) are blocked by the browser. Per the CSP spec, the `nonce` keyword applies ONLY to inline `<script>` / `<style>` blocks — not to event-handler attributes. `$this->Form->postLink(...)` emits `onclick="document.post_X.submit(); ..."` and is therefore unsafe under strict CSP.

## Changes

- Replace 4 `Form->postLink` calls (`edit.php`, `view.php` x2, `index.php`) with `Form->postButton` (preserves the confirmation UX via `form[data-confirm-message]` + a JS delegate).
- Add 3 inline `<script>` blocks with `nonce` (one per admin template) that attach the delegated `submit` listener.

The plugin has no dedicated layout, so the delegate lives in the individual admin templates that render `postButton` forms.

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
- <?= $this->Form->postLink('Delete', [...], ['confirm' => 'Sure?']) ?>
+ <?= $this->Form->postButton('Delete', [...], [
+     'class' => 'btn btn-link',
+     'form' => [
+         'class' => 'd-inline',
+         'data-confirm-message' => 'Sure?',
+     ],
+ ]) ?>
```
