### PR TITLE
Add Comments.adminAccess Closure default-deny gate

### DIFF
--- a/src/Controller/Admin/CommentsController.php
+++ b/src/Controller/Admin/CommentsController.php
@@ -4,12 +4,72 @@ declare(strict_types=1);
 namespace Comments\Controller\Admin;
 
 use App\Controller\AppController;
+use Cake\Core\Configure;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\Log\Log;
+use Closure;
+use Throwable;
 
 /**
+ * Admin namespace for the Comments plugin.
+ *
+ * The default policy is **deny**: the host application MUST set
+ * `Comments.adminAccess` to a `Closure` that receives the current request
+ * and returns literal `true` to grant access. Anything else (unset,
+ * non-Closure, returns false, returns a truthy non-bool, or throws) yields
+ * a 403. (Patterned after Queue.adminAccess.)
+ *
+ * ```php
+ * Configure::write('Comments.adminAccess', function (\Cake\Http\ServerRequest $request): bool {
+ *     $identity = $request->getAttribute('identity');
+ *     return $identity !== null && in_array('admin', (array)$identity->roles, true);
+ * });
+ * ```
+ *
  * @property \Comments\Model\Table\CommentsTable $Comments
  * @method \Comments\Model\Entity\Comment[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
  */
 class CommentsController extends AppController {
+
+	/**
+	 * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event
+	 *
+	 * @throws \Cake\Http\Exception\ForbiddenException When access is denied or unconfigured.
+	 *
+	 * @return void
+	 */
+	public function beforeFilter(EventInterface $event): void {
+		parent::beforeFilter($event);
+
+		// Coexist with cakephp/authorization: the gate IS the authorization decision
+		// for these controllers, so silence the policy check.
+		if ($this->components()->has('Authorization') && method_exists($this->components()->get('Authorization'), 'skipAuthorization')) {
+			$this->components()->get('Authorization')->skipAuthorization();
+		}
+
+		$gate = Configure::read('Comments.adminAccess');
+		if (!($gate instanceof Closure)) {
+			throw new ForbiddenException(__d(
+				'comments',
+				'Comments admin backend is not configured. Set Comments.adminAccess to a Closure that returns true for permitted callers.',
+			));
+		}
+
+		try {
+			$allowed = $gate($this->request) === true;
+		} catch (ForbiddenException $e) {
+			throw $e;
+		} catch (Throwable $e) {
+			Log::warning(sprintf('Comments.adminAccess threw %s: %s', $e::class, $e->getMessage()));
+
+			throw new ForbiddenException(__d('comments', 'Comments admin access denied.'));
+		}
+
+		if (!$allowed) {
+			throw new ForbiddenException(__d('comments', 'Comments admin access denied.'));
+		}
+	}
 
 	/**
 	 * @return \Cake\Http\Response|null|void Renders view

--- a/tests/TestCase/Controller/Admin/CommentsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/CommentsControllerTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Comments\Test\TestCase\Controller\Admin;
 
+use Cake\Core\Configure;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\TestSuite\IntegrationTestTrait;
@@ -24,6 +25,28 @@ class CommentsControllerTest extends TestCase {
 		'plugin.Comments.Comments',
 		'plugin.Comments.Users',
 	];
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// The plugin's beforeFilter requires `Comments.adminAccess` to be a Closure
+		// returning true for permitted callers.
+		Configure::write('Comments.adminAccess', function ($request): bool {
+			return true;
+		});
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Configure::delete('Comments.adminAccess');
+
+		parent::tearDown();
+	}
 
 	/**
 	 * Test edit method (POST)


### PR DESCRIPTION
## Summary

The Comments admin namespace (`index`, `view`, `edit`, `delete`) currently relies entirely on the host app routing the `Admin` prefix through its own auth middleware. Any host that mounts `Admin/Comments` without that protection exposes mass-edit and mass-delete of every comment in the system.

This PR adds a default-deny gate modeled on the recently-introduced `Queue.adminAccess` pattern: host apps must explicitly configure `Comments.adminAccess` as a Closure that returns `true` for permitted callers; otherwise the controller throws `ForbiddenException`.

```php
Configure::write('Comments.adminAccess', function (\Cake\Http\ServerRequest \$request): bool {
    \$identity = \$request->getAttribute('identity');
    return \$identity !== null && in_array('admin', (array)\$identity->roles, true);
});
```

Anything other than a Closure returning literal `true` (unset, non-Closure, returns false, returns a truthy non-bool, or throws) yields a 403. The gate coexists with `cakephp/authorization` by skipping the policy check — the gate IS the authorization decision for these controllers.

## Tests

`Admin\CommentsControllerTest` configures a permissive `Comments.adminAccess` in `setUp` and clears it in `tearDown`, so existing tests keep passing while individual deny-path tests can override the gate. 4/4 tests pass.