### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/comments.pot
+++ b/resources/locales/comments.pot
@@ -1,0 +1,133 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 04:16+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "Comments admin backend is not configured. Set Comments.adminAccess to a Closure that returns true for permitted callers."
+msgstr ""
+
+msgid "Comments admin access denied."
+msgstr ""
+
+msgid "The comment has been saved."
+msgstr ""
+
+msgid "The comment could not be saved. Please, try again."
+msgstr ""
+
+msgid "The comment has been deleted."
+msgstr ""
+
+msgid "The comment could not be deleted. Please, try again."
+msgstr ""
+
+msgid "Could not save comment, please try again."
+msgstr ""
+
+msgid "The Comment has been saved."
+msgstr ""
+
+msgid "The Comment could not be saved. Please, try again."
+msgstr ""
+
+msgid "The Comment has been deleted."
+msgstr ""
+
+msgid "Error appear during comment deleting. Try later."
+msgstr ""
+
+msgid "Please enter a valid email address"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+msgid "List Comments"
+msgstr ""
+
+msgid "Comments"
+msgstr ""
+
+msgid "Edit Comment"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Edit {0}"
+msgstr ""
+
+msgid "Comment"
+msgstr ""
+
+msgid "Delete {0}"
+msgstr ""
+
+msgid "List {0}"
+msgstr ""
+
+msgid "User"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Is Private"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "Is Spam"
+msgstr ""
+
+msgid "Content"
+msgstr ""
+
+msgid "Related Comments"
+msgstr ""
+
+msgid "Id"
+msgstr ""
+
+msgid "Foreign Key"
+msgstr ""
+
+msgid "Model"
+msgstr ""
+
+msgid "User Id"
+msgstr ""
+
+msgid "Add Comment"
+msgstr ""
+

--- a/src/Controller/Admin/CommentsController.php
+++ b/src/Controller/Admin/CommentsController.php
@@ -102,11 +102,11 @@ class CommentsController extends AppController {
 		if ($this->request->is(['patch', 'post', 'put'])) {
 			$comment = $this->Comments->patchEntity($comment, $this->request->getData());
 			if ($this->Comments->save($comment)) {
-				$this->Flash->success(__('The comment has been saved.'));
+				$this->Flash->success(__d('comments', 'The comment has been saved.'));
 
 				return $this->redirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('The comment could not be saved. Please, try again.'));
+			$this->Flash->error(__d('comments', 'The comment could not be saved. Please, try again.'));
 		}
 		$parentComments = $this->Comments->ParentComments->find('list', limit: 1000)->all();
 		$this->set(compact('comment', 'parentComments'));
@@ -121,9 +121,9 @@ class CommentsController extends AppController {
 		$this->request->allowMethod(['post', 'delete']);
 		$comment = $this->Comments->get($id);
 		if ($this->Comments->delete($comment)) {
-			$this->Flash->success(__('The comment has been deleted.'));
+			$this->Flash->success(__d('comments', 'The comment has been deleted.'));
 		} else {
-			$this->Flash->error(__('The comment could not be deleted. Please, try again.'));
+			$this->Flash->error(__d('comments', 'The comment could not be deleted. Please, try again.'));
 		}
 
 		return $this->redirect(['action' => 'index']);

--- a/src/Model/Table/CommentsTable.php
+++ b/src/Model/Table/CommentsTable.php
@@ -70,7 +70,7 @@ class CommentsTable extends Table {
 		$validator->requirePresence('model', 'create');
 		$validator->notEmptyString('foreign_key');
 		$validator->requirePresence('foreign_key', 'create');
-		$validator->email('email', false, __('Please enter a valid email address'));
+		$validator->email('email', false, __d('comments', 'Please enter a valid email address'));
 
 		return $validator;
 	}

--- a/templates/Admin/Comments/edit.php
+++ b/templates/Admin/Comments/edit.php
@@ -10,28 +10,28 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 <div class="row">
     <aside class="column large-3 medium-4 columns col-sm-4 col-12">
         <ul class="side-nav nav nav-pills flex-column">
-            <li class="nav-item heading"><?= __('Actions') ?></li>
+            <li class="nav-item heading"><?= __d('comments', 'Actions') ?></li>
             <li class="nav-item"><?= $this->Form->postButton(
-                __('Delete'),
+                __d('comments', 'Delete'),
                 ['action' => 'delete', $comment->id],
                 [
                     'class' => 'side-nav-item btn btn-link text-start w-100',
                     'form' => [
                         'class' => 'd-inline',
-                        'data-confirm-message' => __('Are you sure you want to delete # {0}?', $comment->id),
+                        'data-confirm-message' => __d('comments', 'Are you sure you want to delete # {0}?', $comment->id),
                     ],
                 ]
                 ) ?></li>
-            <li class="nav-item"><?= $this->Html->link(__('List Comments'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
+            <li class="nav-item"><?= $this->Html->link(__d('comments', 'List Comments'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
         </ul>
     </aside>
     <div class="column-responsive column-80 form large-9 medium-8 columns col-sm-8 col-12">
         <div class="comments form content">
-            <h2><?= __('Comments') ?></h2>
+            <h2><?= __d('comments', 'Comments') ?></h2>
 
             <?= $this->Form->create($comment) ?>
             <fieldset>
-                <legend><?= __('Edit Comment') ?></legend>
+                <legend><?= __d('comments', 'Edit Comment') ?></legend>
                 <?php
                     echo $this->Form->control('model');
                     echo $this->Form->control('foreign_key');
@@ -42,7 +42,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
                     echo $this->Form->control('is_spam');
                 ?>
             </fieldset>
-            <?= $this->Form->button(__('Submit')) ?>
+            <?= $this->Form->button(__d('comments', 'Submit')) ?>
             <?= $this->Form->end() ?>
         </div>
     </div>

--- a/templates/Admin/Comments/index.php
+++ b/templates/Admin/Comments/index.php
@@ -7,14 +7,14 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills flex-column">
-        <li class="nav-item heading"><?= __('Actions') ?></li>
+        <li class="nav-item heading"><?= __d('comments', 'Actions') ?></li>
         <li class="nav-item">
         </li>
     </ul>
 </nav>
 <div class="comments index content large-9 medium-8 columns col-sm-8 col-12">
 
-    <h2><?= __('Comments') ?></h2>
+    <h2><?= __d('comments', 'Comments') ?></h2>
 
     <div class="">
         <table class="table table-sm table-striped">
@@ -30,7 +30,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
                     <th><?= $this->Paginator->sort('is_spam') ?></th>
                     <th><?= $this->Paginator->sort('created', null, ['direction' => 'desc']) ?></th>
                     <th><?= $this->Paginator->sort('modified', null, ['direction' => 'desc']) ?></th>
-                    <th class="actions"><?= __('Actions') ?></th>
+                    <th class="actions"><?= __d('comments', 'Actions') ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -58,7 +58,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
                             'class' => 'btn btn-link p-0 align-baseline',
                             'form' => [
                                 'class' => 'd-inline',
-                                'data-confirm-message' => __('Are you sure you want to delete # {0}?', $comment->id),
+                                'data-confirm-message' => __d('comments', 'Are you sure you want to delete # {0}?', $comment->id),
                             ],
                         ]); ?>
                     </td>

--- a/templates/Admin/Comments/view.php
+++ b/templates/Admin/Comments/view.php
@@ -8,16 +8,16 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 <div class="row">
     <aside class="column actions large-3 medium-4 col-sm-4 col-xs-12">
         <ul class="side-nav nav nav-pills flex-column">
-            <li class="nav-item heading"><?= __('Actions') ?></li>
-            <li class="nav-item"><?= $this->Html->link(__('Edit {0}', __('Comment')), ['action' => 'edit', $comment->id], ['class' => 'side-nav-item']) ?></li>
-            <li class="nav-item"><?= $this->Form->postButton(__('Delete {0}', __('Comment')), ['action' => 'delete', $comment->id], [
+            <li class="nav-item heading"><?= __d('comments', 'Actions') ?></li>
+            <li class="nav-item"><?= $this->Html->link(__d('comments', 'Edit {0}', __d('comments', 'Comment')), ['action' => 'edit', $comment->id], ['class' => 'side-nav-item']) ?></li>
+            <li class="nav-item"><?= $this->Form->postButton(__d('comments', 'Delete {0}', __d('comments', 'Comment')), ['action' => 'delete', $comment->id], [
                 'class' => 'side-nav-item btn btn-link text-start w-100',
                 'form' => [
                     'class' => 'd-inline',
-                    'data-confirm-message' => __('Are you sure you want to delete # {0}?', $comment->id),
+                    'data-confirm-message' => __d('comments', 'Are you sure you want to delete # {0}?', $comment->id),
                 ],
             ]) ?></li>
-            <li class="nav-item"><?= $this->Html->link(__('List {0}', __('Comments')), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
+            <li class="nav-item"><?= $this->Html->link(__d('comments', 'List {0}', __d('comments', 'Comments')), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
         </ul>
     </aside>
     <div class="column-responsive column-80 content large-9 medium-8 col-sm-8 col-xs-12">
@@ -26,58 +26,58 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 
             <table class="table table-striped">
                 <tr>
-                    <th><?= __('User') ?></th>
+                    <th><?= __d('comments', 'User') ?></th>
                     <td><?= $comment->hasValue('user') ? $this->Html->link($comment->user->username, ['controller' => 'Users', 'action' => 'view', $comment->user->id]) : '' ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Name') ?></th>
+                    <th><?= __d('comments', 'Name') ?></th>
                     <td><?= h($comment->name) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Email') ?></th>
+                    <th><?= __d('comments', 'Email') ?></th>
                     <td><?= h($comment->email) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Created') ?></th>
+                    <th><?= __d('comments', 'Created') ?></th>
                     <td><?= $this->Time->nice($comment->created) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Modified') ?></th>
+                    <th><?= __d('comments', 'Modified') ?></th>
                     <td><?= $this->Time->nice($comment->modified) ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Is Private') ?></th>
-                    <td><?= $this->IconSnippet->yesNo($comment->is_private) ?> <?= $comment->is_private ? __('Yes') : __('No'); ?></td>
+                    <th><?= __d('comments', 'Is Private') ?></th>
+                    <td><?= $this->IconSnippet->yesNo($comment->is_private) ?> <?= $comment->is_private ? __d('comments', 'Yes') : __d('comments', 'No'); ?></td>
                 </tr>
                 <tr>
-                    <th><?= __('Is Spam') ?></th>
-                    <td><?= $this->IconSnippet->yesNo($comment->is_spam) ?> <?= $comment->is_spam ? __('Yes') : __('No'); ?></td>
+                    <th><?= __d('comments', 'Is Spam') ?></th>
+                    <td><?= $this->IconSnippet->yesNo($comment->is_spam) ?> <?= $comment->is_spam ? __d('comments', 'Yes') : __d('comments', 'No'); ?></td>
                 </tr>
             </table>
             <div class="text">
-                <strong><?= __('Content') ?></strong>
+                <strong><?= __d('comments', 'Content') ?></strong>
                 <blockquote>
                     <?= $this->Text->autoParagraph(h($comment->content)); ?>
                 </blockquote>
             </div>
             <div class="related">
-                <h4><?= __('Related Comments') ?></h4>
+                <h4><?= __d('comments', 'Related Comments') ?></h4>
                 <?php if (!empty($comment->child_comments)) : ?>
                 <div>
                     <table class="table table-striped">
                         <tr>
-                            <th><?= __('Id') ?></th>
-                            <th><?= __('Foreign Key') ?></th>
-                            <th><?= __('Model') ?></th>
-                            <th><?= __('User Id') ?></th>
-                            <th><?= __('Name') ?></th>
-                            <th><?= __('Email') ?></th>
-                            <th><?= __('Content') ?></th>
-                            <th><?= __('Is Private') ?></th>
-                            <th><?= __('Is Spam') ?></th>
-                            <th><?= __('Created') ?></th>
-                            <th><?= __('Modified') ?></th>
-                            <th class="actions"><?= __('Actions') ?></th>
+                            <th><?= __d('comments', 'Id') ?></th>
+                            <th><?= __d('comments', 'Foreign Key') ?></th>
+                            <th><?= __d('comments', 'Model') ?></th>
+                            <th><?= __d('comments', 'User Id') ?></th>
+                            <th><?= __d('comments', 'Name') ?></th>
+                            <th><?= __d('comments', 'Email') ?></th>
+                            <th><?= __d('comments', 'Content') ?></th>
+                            <th><?= __d('comments', 'Is Private') ?></th>
+                            <th><?= __d('comments', 'Is Spam') ?></th>
+                            <th><?= __d('comments', 'Created') ?></th>
+                            <th><?= __d('comments', 'Modified') ?></th>
+                            <th class="actions"><?= __d('comments', 'Actions') ?></th>
                         </tr>
                         <?php foreach ($comment->child_comments as $childComments) : ?>
                         <tr>
@@ -100,7 +100,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
                                     'class' => 'btn btn-link p-0 align-baseline',
                                     'form' => [
                                         'class' => 'd-inline',
-                                        'data-confirm-message' => __('Are you sure you want to delete # {0}?', $childComments->id),
+                                        'data-confirm-message' => __d('comments', 'Are you sure you want to delete # {0}?', $childComments->id),
                                     ],
                                 ]); ?>
                             </td>

--- a/templates/Comments/add.php
+++ b/templates/Comments/add.php
@@ -9,15 +9,15 @@
 <div class="row">
     <aside class="column">
         <div class="side-nav">
-            <h4 class="heading"><?= __('Actions') ?></h4>
-            <?= $this->Html->link(__('List Comments'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
+            <h4 class="heading"><?= __d('comments', 'Actions') ?></h4>
+            <?= $this->Html->link(__d('comments', 'List Comments'), ['action' => 'index'], ['class' => 'side-nav-item']) ?>
         </div>
     </aside>
     <div class="column column-80">
         <div class="comments form content">
             <?= $this->Form->create($comment) ?>
             <fieldset>
-                <legend><?= __('Add Comment') ?></legend>
+                <legend><?= __d('comments', 'Add Comment') ?></legend>
                 <?php
                     echo $this->Form->control('foreign_key');
                     echo $this->Form->control('model');
@@ -29,7 +29,7 @@
                     echo $this->Form->control('is_spam');
                 ?>
             </fieldset>
-            <?= $this->Form->button(__('Submit')) ?>
+            <?= $this->Form->button(__d('comments', 'Submit')) ?>
             <?= $this->Form->end() ?>
         </div>
     </div>


### PR DESCRIPTION
## Summary

- Convert 49 `__()` calls in `src/` and `templates/` to `__d('comments', ...)` so plugin strings live in their own domain. The 8 pre-existing `__d('comments', ...)` calls already pointed at the right domain — the rest of the plugin now matches.
- Add `resources/locales/comments.pot` (39 unique msgids) generated via `bin/cake i18n extract`.

## Why

Plugin strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible.

## Verification (local)

- phpunit: 92 / 92 (1 pre-existing notice + 1 PHP notice — both unrelated)
- phpstan: no errors
- phpcs: clean