### PR TITLE
Harden public comment creation and deletion access

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ Configure the session key in your `config/app.php`:
 
 ```php
 'Comments' => [
+    'allowAnonymous' => false, // Default: require a logged-in user for public comment creation
     'sessionKey' => 'Auth', // For CakeDC/Users or Authentication plugin
     // 'sessionKey' => 'Auth.User', // Default (legacy Auth)
     'userIdField' => 'id', // The field in the user identity containing the user ID
@@ -86,6 +87,10 @@ $this->loadComponent('Comments.Comment', [
     'sessionKey' => 'Auth',
 ]);
 ```
+
+Anonymous comments are only accepted when `Comments.allowAnonymous` is explicitly enabled.
+Public comment deletion is restricted to the comment owner, unless `Comments.adminAccess`
+grants elevated access for the current request.
 
 ## Admin Backend
 Go to `/admin/comments`.

--- a/src/Controller/CommentsController.php
+++ b/src/Controller/CommentsController.php
@@ -4,7 +4,9 @@ namespace Comments\Controller;
 
 use App\Controller\AppController;
 use Cake\Core\Configure;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\NotFoundException;
+use Closure;
 use TinyAuth\Controller\Component\AuthUserComponent;
 
 /**
@@ -36,6 +38,11 @@ class CommentsController extends AppController {
 	public function add($alias = null, $id = null) {
 		$this->request->allowMethod(['post', 'put', 'patch']);
 		$data = $this->request->getData();
+		$userId = $this->userId();
+
+		if (!$this->allowsAnonymous() && $userId === null) {
+			throw new ForbiddenException(__d('comments', 'Anonymous comments are disabled.'));
+		}
 
 		$model = Configure::read('Comments.controllerModels.' . $alias);
 		if (!$model) {
@@ -46,7 +53,7 @@ class CommentsController extends AppController {
 
 		$data['model'] = $model;
 		$data['foreign_key'] = $entity->get('id');
-		$data['user_id'] = $this->userId();
+		$data['user_id'] = $userId;
 		$data['content'] = $data['comment'] ?? $data['content'] ?? null;
 
 		$result = $this->Comments->add($data);
@@ -86,10 +93,39 @@ class CommentsController extends AppController {
 
 		$id = $this->request->getData('id') ?: $id;
 		$comment = $this->Comments->get($id);
+		if (!$this->canDelete($comment->user_id)) {
+			throw new ForbiddenException(__d('comments', 'You are not allowed to delete this comment.'));
+		}
 
 		$this->Comments->delete($comment);
 
 		return $this->redirect($this->referer(['action' => 'index']));
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function allowsAnonymous(): bool {
+		return (bool)Configure::read('Comments.allowAnonymous', false);
+	}
+
+	/**
+	 * @param int|null $commentUserId
+	 *
+	 * @return bool
+	 */
+	protected function canDelete(?int $commentUserId): bool {
+		$userId = $this->userId();
+		if ($userId !== null && $commentUserId !== null && $userId === $commentUserId) {
+			return true;
+		}
+
+		$gate = Configure::read('Comments.adminAccess');
+		if ($gate instanceof Closure) {
+			return $gate($this->request) === true;
+		}
+
+		return false;
 	}
 
 }

--- a/tests/TestCase/Controller/CommentsControllerTest.php
+++ b/tests/TestCase/Controller/CommentsControllerTest.php
@@ -5,6 +5,7 @@ namespace Comments\Test\TestCase\Controller;
 
 use Cake\Core\Configure;
 use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\TestSuite\IntegrationTestTrait;
@@ -36,6 +37,8 @@ class CommentsControllerTest extends TestCase {
 	 * @return void
 	 */
 	protected function tearDown(): void {
+		Configure::delete('Comments.allowAnonymous');
+		Configure::delete('Comments.adminAccess');
 		Configure::delete('Comments.controllerModels');
 
 		parent::tearDown();
@@ -52,6 +55,7 @@ class CommentsControllerTest extends TestCase {
 		$this->disableErrorHandlerMiddleware();
 		$this->enableRetainFlashMessages();
 
+		Configure::write('Comments.allowAnonymous', true);
 		Configure::write('Comments.controllerModels.Posts', 'Posts');
 
 		$data = [
@@ -76,6 +80,7 @@ class CommentsControllerTest extends TestCase {
 	public function testAddWithContentField(): void {
 		$this->disableErrorHandlerMiddleware();
 
+		Configure::write('Comments.allowAnonymous', true);
 		Configure::write('Comments.controllerModels.Posts', 'Posts');
 
 		$data = [
@@ -103,6 +108,7 @@ class CommentsControllerTest extends TestCase {
 	 */
 	public function testAddInvalidAlias(): void {
 		$this->disableErrorHandlerMiddleware();
+		Configure::write('Comments.allowAnonymous', true);
 
 		$data = [
 			'comment' => 'Test',
@@ -123,6 +129,7 @@ class CommentsControllerTest extends TestCase {
 	public function testAddInvalidModelId(): void {
 		$this->disableErrorHandlerMiddleware();
 
+		Configure::write('Comments.allowAnonymous', true);
 		Configure::write('Comments.controllerModels.Posts', 'Posts');
 
 		$data = [
@@ -144,6 +151,7 @@ class CommentsControllerTest extends TestCase {
 	public function testAddGetNotAllowed(): void {
 		$this->disableErrorHandlerMiddleware();
 
+		Configure::write('Comments.allowAnonymous', true);
 		Configure::write('Comments.controllerModels.Posts', 'Posts');
 
 		$this->expectException(MethodNotAllowedException::class);
@@ -162,6 +170,7 @@ class CommentsControllerTest extends TestCase {
 		$this->disableErrorHandlerMiddleware();
 		$this->enableRetainFlashMessages();
 
+		Configure::write('Comments.allowAnonymous', true);
 		Configure::write('Comments.controllerModels.Posts', 'Posts');
 
 		$data = [
@@ -212,15 +221,30 @@ class CommentsControllerTest extends TestCase {
 	 */
 	public function testAddAnonymous(): void {
 		$this->disableErrorHandlerMiddleware();
-		$this->enableRetainFlashMessages();
-
 		Configure::write('Comments.controllerModels.Posts', 'Posts');
 
-		$data = [
-			'comment' => 'Anonymous comment',
-		];
+		$this->expectException(ForbiddenException::class);
 
-		$this->post(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'add', 'Posts', 1], $data);
+		$this->post(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'add', 'Posts', 1], [
+			'comment' => 'Anonymous comment',
+		]);
+	}
+
+	/**
+	 * @uses \Comments\Controller\CommentsController::add()
+	 *
+	 * @return void
+	 */
+	public function testAddAnonymousAllowed(): void {
+		$this->disableErrorHandlerMiddleware();
+		$this->enableRetainFlashMessages();
+
+		Configure::write('Comments.allowAnonymous', true);
+		Configure::write('Comments.controllerModels.Posts', 'Posts');
+
+		$this->post(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'add', 'Posts', 1], [
+			'comment' => 'Anonymous comment',
+		]);
 
 		$this->assertRedirect(['action' => 'index']);
 
@@ -242,6 +266,7 @@ class CommentsControllerTest extends TestCase {
 		$this->disableErrorHandlerMiddleware();
 		$this->enableRetainFlashMessages();
 
+		Configure::write('Comments.allowAnonymous', true);
 		Configure::write('Comments.controllerModels.Posts', 'Posts');
 
 		$data = [
@@ -261,7 +286,15 @@ class CommentsControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testDelete(): void {
-		$comment = $this->fetchTable('Comments.Comments')->find()->firstOrFail();
+		$comment = $this->fetchTable('Comments.Comments')->saveOrFail(
+			$this->fetchTable('Comments.Comments')->newEntity([
+				'foreign_key' => 1,
+				'model' => 'Posts',
+				'user_id' => 1,
+				'content' => 'Owned comment',
+			]),
+		);
+		$this->session(['Auth.User.id' => 1]);
 
 		$this->delete(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'delete', $comment->id]);
 
@@ -276,7 +309,15 @@ class CommentsControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testDeleteWithDataId(): void {
-		$comment = $this->fetchTable('Comments.Comments')->find()->firstOrFail();
+		$comment = $this->fetchTable('Comments.Comments')->saveOrFail(
+			$this->fetchTable('Comments.Comments')->newEntity([
+				'foreign_key' => 1,
+				'model' => 'Posts',
+				'user_id' => 1,
+				'content' => 'Owned comment via post',
+			]),
+		);
+		$this->session(['Auth.User.id' => 1]);
 
 		$this->post(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'delete'], ['id' => $comment->id]);
 
@@ -295,6 +336,7 @@ class CommentsControllerTest extends TestCase {
 	 */
 	public function testDeleteInvalidId(): void {
 		$this->disableErrorHandlerMiddleware();
+		$this->session(['Auth.User.id' => 1]);
 
 		$this->expectException(RecordNotFoundException::class);
 
@@ -311,11 +353,59 @@ class CommentsControllerTest extends TestCase {
 	public function testDeleteGetNotAllowed(): void {
 		$this->disableErrorHandlerMiddleware();
 
-		$comment = $this->fetchTable('Comments.Comments')->find()->firstOrFail();
+		$comment = $this->fetchTable('Comments.Comments')->saveOrFail(
+			$this->fetchTable('Comments.Comments')->newEntity([
+				'foreign_key' => 1,
+				'model' => 'Posts',
+				'user_id' => 1,
+				'content' => 'Owned comment for method test',
+			]),
+		);
+		$this->session(['Auth.User.id' => 1]);
 
 		$this->expectException(MethodNotAllowedException::class);
 
 		$this->get(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'delete', $comment->id]);
+	}
+
+	/**
+	 * @uses \Comments\Controller\CommentsController::delete()
+	 *
+	 * @return void
+	 */
+	public function testDeleteForbiddenForOtherUser(): void {
+		$this->disableErrorHandlerMiddleware();
+
+		$comment = $this->fetchTable('Comments.Comments')->saveOrFail(
+			$this->fetchTable('Comments.Comments')->newEntity([
+				'foreign_key' => 1,
+				'model' => 'Posts',
+				'user_id' => 1,
+				'content' => 'Other user comment',
+			]),
+		);
+		$this->session(['Auth.User.id' => 999]);
+
+		$this->expectException(ForbiddenException::class);
+
+		$this->delete(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'delete', $comment->id]);
+	}
+
+	/**
+	 * @uses \Comments\Controller\CommentsController::delete()
+	 *
+	 * @return void
+	 */
+	public function testDeleteAllowedForAdminAccessGate(): void {
+		$comment = $this->fetchTable('Comments.Comments')->find()->firstOrFail();
+		Configure::write('Comments.adminAccess', static function (): bool {
+			return true;
+		});
+
+		$this->delete(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'delete', $comment->id]);
+
+		$this->assertRedirect(['action' => 'index']);
+		$this->assertFalse($this->fetchTable('Comments.Comments')->exists(['id' => $comment->id]));
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- require public comment deletion to be performed by the comment owner or an elevated `Comments.adminAccess` gate
- make `CommentsController::add()` honor `Comments.allowAnonymous` instead of silently accepting anonymous posts
- document the public-access behavior in the plugin docs

## Tests
- `vendor/bin/phpunit tests/TestCase/Controller/CommentsControllerTest.php`
- `vendor/bin/phpunit`
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyze`

## Notes
- Full PHPUnit is green, but the suite still contains one pre-existing `CommentComponent` notice about `AppController::$params` that is unrelated to this PR.
