### PR TITLE
Lock comment mass assignment and remove cross-record IDOR

### DIFF
--- a/src/Controller/CommentsController.php
+++ b/src/Controller/CommentsController.php
@@ -55,6 +55,10 @@ class CommentsController extends AppController {
 		$data['foreign_key'] = $entity->get('id');
 		$data['user_id'] = $userId;
 		$data['content'] = $data['comment'] ?? $data['content'] ?? null;
+		// The public `add` action does not support threading — clear any
+		// request-supplied parent_id so it can't be used to attach a top-level
+		// comment under an unrelated parent (cross-thread IDOR).
+		$data['parent_id'] = null;
 
 		$result = $this->Comments->add($data);
 		if ($result->isNew()) {

--- a/src/Model/Behavior/CommentableBehavior.php
+++ b/src/Model/Behavior/CommentableBehavior.php
@@ -121,13 +121,11 @@ class CommentableBehavior extends Behavior {
 		}
 
 		if ($commentId) {
-			//$this->commentsTable()->id = $commentId;
 			if (
 				!$this->commentsTable()->find()
 					->where([
-						'Comment.id' => $commentId,
-						'Comment.approved' => true,
-						'Comment.foreign_key' => $options['modelId'],
+						'Comments.id' => $commentId,
+						'Comments.foreign_key' => $options['modelId'],
 					])
 					->count()
 			) {
@@ -138,14 +136,15 @@ class CommentableBehavior extends Behavior {
 		$data = $options['data'];
 		$data['content'] = $data['comment'] ?? $data['content'] ?? null;
 		if ($data) {
+			// Identity / relational columns are set unconditionally from the
+			// caller's options. The request body never decides which record
+			// or which thread a new comment lands on — otherwise a forged
+			// `foreign_key` / `parent_id` lets an attacker attach a comment
+			// to any record they like, or thread under any parent.
 			$data['user_id'] = $options['userId'];
 			$data['model'] = $options['model'];
-			if (!isset($data['foreign_key'])) {
-				$data['foreign_key'] = $options['modelId'];
-			}
-			if (!isset($data['parent_id'])) {
-				$data['parent_id'] = $commentId;
-			}
+			$data['foreign_key'] = $options['modelId'];
+			$data['parent_id'] = $commentId;
 			if (empty($data['title'])) {
 				$data['title'] = $options['defaultTitle'];
 			}
@@ -169,36 +168,27 @@ class CommentableBehavior extends Behavior {
             }
             */
 
-			$comment = $this->commentsTable()->newEntity($data);
+			$comment = $this->commentsTable()->patchEntity(
+				$this->commentsTable()->newEmptyEntity(),
+				$data,
+				[
+					'accessibleFields' => [
+						'user_id' => true,
+						'model' => true,
+						'foreign_key' => true,
+						'parent_id' => true,
+					],
+				],
+			);
 
 			if ($this->commentsTable()->behaviors()->has('Tree')) {
-				if (isset($data['foreign_key'])) {
-					$fk = $data['foreign_key'];
-				} elseif (isset($data['model_id'])) {
-					$fk = $data['model_id'];
-				} else {
-					$fk = null;
-				}
 				$this->commentsTable()->behaviors()->load('Tree', [
-					'scope' => ['Comments.foreign_key' => $fk],
+					'scope' => ['Comments.foreign_key' => $data['foreign_key']],
 				]);
 			}
 
 			if ($this->commentsTable()->save($comment)) {
-				$id = $comment->id;
-				//$data['id'] = $id;
-				//$this->commentsTable()->data[$this->commentsTable()->alias]['id'] = $id;
-				if (!isset($data['approved']) || $data['approved'] == true) {
-					//$this->changeCommentCount($Model, $modelId);
-				}
-
-				//$event = new CakeEvent('Behavior.Commentable.afterCreateComment', $Model, $this->commentsTable()->data);
-				//CakeEventManager::instance()->dispatch($event);
-				//if ($event->isStopped() && !$event->result) {
-				//    return false;
-				//}
-
-				return $id;
+				return $comment->id;
 			}
 
 			return null;

--- a/src/Model/Entity/Comment.php
+++ b/src/Model/Entity/Comment.php
@@ -29,15 +29,19 @@ class Comment extends Entity {
 	/**
 	 * Fields that can be mass assigned using newEntity() or patchEntity().
 	 *
-	 * Note that when '*' is set to true, this allows all unspecified fields to
-	 * be mass assigned. For security purposes, it is advised to set '*' to false
-	 * (or remove it), and explicitly make individual fields accessible as needed.
+	 * Only public-form fields are accessible. Identity / relational columns
+	 * (`user_id`, `model`, `foreign_key`, `parent_id`) and moderation flags
+	 * (`is_private`, `is_spam`) must be set by trusted server-side code,
+	 * never by request data, otherwise an attacker can cross-post a comment
+	 * onto an arbitrary record or pre-approve their own spam.
 	 *
 	 * @var array<string, bool>
 	 */
 	protected array $_accessible = [
-		'*' => true,
-		'id' => false,
+		'name' => true,
+		'email' => true,
+		'title' => true,
+		'content' => true,
 	];
 
 }

--- a/src/Model/Table/CommentsTable.php
+++ b/src/Model/Table/CommentsTable.php
@@ -91,17 +91,36 @@ class CommentsTable extends Table {
 	}
 
 	/**
+	 * Persist a new comment using server-trusted data.
+	 *
+	 * The entity's `_accessible` allowlist intentionally excludes
+	 * `user_id`, `model`, `foreign_key`, and `parent_id` so that request
+	 * bodies cannot mass-assign them. Callers of `add()` are expected to
+	 * have set those columns themselves from authenticated/server-side
+	 * state, so we allow them through here via `accessibleFields`.
+	 *
 	 * @param array $data
 	 *
 	 * @return \Comments\Model\Entity\Comment
 	 */
 	public function add(array $data): Comment {
-		$comment = $this->newEntity($data);
+		$comment = $this->patchEntity(
+			$this->newEmptyEntity(),
+			$data,
+			[
+				'accessibleFields' => [
+					'user_id' => true,
+					'model' => true,
+					'foreign_key' => true,
+					'parent_id' => true,
+				],
+			],
+		);
 		if ($comment->hasErrors()) {
 			return $comment;
 		}
 
-		$this->saveOrFail($comment);
+		$this->save($comment);
 
 		return $comment;
 	}

--- a/tests/TestCase/Controller/CommentsControllerTest.php
+++ b/tests/TestCase/Controller/CommentsControllerTest.php
@@ -10,6 +10,7 @@ use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use Comments\Model\Entity\Comment;
 
 /**
  * Comments\Controller\CommentsController Test Case
@@ -42,6 +43,22 @@ class CommentsControllerTest extends TestCase {
 		Configure::delete('Comments.controllerModels');
 
 		parent::tearDown();
+	}
+
+	/**
+	 * Build a saved Comment for a test, bypassing the entity's tight
+	 * `_accessible` allowlist that blocks `user_id` / `model` / `foreign_key`
+	 * from mass assignment. Production code sets those server-side; tests
+	 * mimic that by passing `accessibleFields` explicitly.
+	 *
+	 * @param array<string, mixed> $fields
+     *
+	 * @return \Comments\Model\Entity\Comment
+	 */
+	protected function makeComment(array $fields): Comment {
+		$table = $this->fetchTable('Comments.Comments');
+
+		return $table->saveOrFail($table->newEntity($fields, ['accessibleFields' => ['*' => true]]));
 	}
 
 	/**
@@ -286,14 +303,12 @@ class CommentsControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testDelete(): void {
-		$comment = $this->fetchTable('Comments.Comments')->saveOrFail(
-			$this->fetchTable('Comments.Comments')->newEntity([
-				'foreign_key' => 1,
-				'model' => 'Posts',
-				'user_id' => 1,
-				'content' => 'Owned comment',
-			]),
-		);
+		$comment = $this->makeComment([
+			'foreign_key' => 1,
+			'model' => 'Posts',
+			'user_id' => 1,
+			'content' => 'Owned comment',
+		]);
 		$this->session(['Auth.User.id' => 1]);
 
 		$this->delete(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'delete', $comment->id]);
@@ -309,14 +324,12 @@ class CommentsControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testDeleteWithDataId(): void {
-		$comment = $this->fetchTable('Comments.Comments')->saveOrFail(
-			$this->fetchTable('Comments.Comments')->newEntity([
-				'foreign_key' => 1,
-				'model' => 'Posts',
-				'user_id' => 1,
-				'content' => 'Owned comment via post',
-			]),
-		);
+		$comment = $this->makeComment([
+			'foreign_key' => 1,
+			'model' => 'Posts',
+			'user_id' => 1,
+			'content' => 'Owned comment via post',
+		]);
 		$this->session(['Auth.User.id' => 1]);
 
 		$this->post(['plugin' => 'Comments', 'controller' => 'Comments', 'action' => 'delete'], ['id' => $comment->id]);
@@ -353,14 +366,12 @@ class CommentsControllerTest extends TestCase {
 	public function testDeleteGetNotAllowed(): void {
 		$this->disableErrorHandlerMiddleware();
 
-		$comment = $this->fetchTable('Comments.Comments')->saveOrFail(
-			$this->fetchTable('Comments.Comments')->newEntity([
-				'foreign_key' => 1,
-				'model' => 'Posts',
-				'user_id' => 1,
-				'content' => 'Owned comment for method test',
-			]),
-		);
+		$comment = $this->makeComment([
+			'foreign_key' => 1,
+			'model' => 'Posts',
+			'user_id' => 1,
+			'content' => 'Owned comment for method test',
+		]);
 		$this->session(['Auth.User.id' => 1]);
 
 		$this->expectException(MethodNotAllowedException::class);
@@ -376,14 +387,12 @@ class CommentsControllerTest extends TestCase {
 	public function testDeleteForbiddenForOtherUser(): void {
 		$this->disableErrorHandlerMiddleware();
 
-		$comment = $this->fetchTable('Comments.Comments')->saveOrFail(
-			$this->fetchTable('Comments.Comments')->newEntity([
-				'foreign_key' => 1,
-				'model' => 'Posts',
-				'user_id' => 1,
-				'content' => 'Other user comment',
-			]),
-		);
+		$comment = $this->makeComment([
+			'foreign_key' => 1,
+			'model' => 'Posts',
+			'user_id' => 1,
+			'content' => 'Other user comment',
+		]);
 		$this->session(['Auth.User.id' => 999]);
 
 		$this->expectException(ForbiddenException::class);

--- a/tests/TestCase/Model/Behavior/CommentableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CommentableBehaviorTest.php
@@ -188,41 +188,47 @@ class CommentableBehaviorTest extends TestCase {
 	}
 
 	/**
-	 * Test commentAdd with parent_id in data
+	 * Threading is controlled by the first argument to commentAdd (the
+	 * parent comment id), not by request data. A `parent_id` smuggled
+	 * into `options.data` must be ignored — otherwise an attacker could
+	 * thread under any parent on the same record without going through
+	 * the parent-validity check.
 	 *
 	 * @return void
 	 */
-	public function testCommentAddWithParentInData(): void {
+	public function testCommentAddIgnoresParentIdInData(): void {
 		$commentsTable = $this->getTableLocator()->get('Comments.Comments');
 
-		// First create a parent comment
-		$parentOptions = [
+		$parentId = $this->Commentable->commentAdd(null, [
 			'userId' => 1,
 			'modelId' => 1,
 			'model' => 'Posts',
-			'data' => [
-				'content' => 'Parent comment',
-			],
-		];
-		$parentId = $this->Commentable->commentAdd(null, $parentOptions);
+			'data' => ['content' => 'Parent comment'],
+		]);
 		$this->assertNotNull($parentId);
 
-		// Now create a child comment with parent_id in data
-		$childOptions = [
+		// Threaded reply via the first arg — works.
+		$childId = $this->Commentable->commentAdd($parentId, [
+			'userId' => 1,
+			'modelId' => 1,
+			'model' => 'Posts',
+			'data' => ['content' => 'Child comment'],
+		]);
+		$this->assertNotNull($childId);
+		$this->assertSame($parentId, $commentsTable->get($childId)->parent_id);
+
+		// Smuggled parent_id in data is ignored — top-level comment, not threaded.
+		$smuggledId = $this->Commentable->commentAdd(null, [
 			'userId' => 1,
 			'modelId' => 1,
 			'model' => 'Posts',
 			'data' => [
-				'content' => 'Child comment',
+				'content' => 'Smuggled',
 				'parent_id' => $parentId,
 			],
-		];
-
-		$childId = $this->Commentable->commentAdd(null, $childOptions);
-		$this->assertNotNull($childId);
-
-		$childComment = $commentsTable->get($childId);
-		$this->assertSame($parentId, $childComment->parent_id);
+		]);
+		$this->assertNotNull($smuggledId);
+		$this->assertNull($commentsTable->get($smuggledId)->parent_id, 'parent_id from request data must NOT be honored.');
 	}
 
 	/**
@@ -383,26 +389,28 @@ class CommentableBehaviorTest extends TestCase {
 	}
 
 	/**
-	 * Test commentAdd with foreign_key in data
+	 * The previous behavior allowed `foreign_key` smuggled into
+	 * `options.data` to override the caller's `modelId` — a clean IDOR
+	 * because the controller's authoritative model id was silently
+	 * replaced by attacker-supplied request data. The comment must now
+	 * always attach to `modelId`, regardless of what `data` says.
 	 *
 	 * @return void
 	 */
-	public function testCommentAddWithForeignKeyInData(): void {
-		$options = [
+	public function testCommentAddIgnoresForeignKeyInData(): void {
+		$result = $this->Commentable->commentAdd(null, [
 			'userId' => 1,
 			'modelId' => 1,
 			'model' => 'Posts',
 			'data' => [
-				'content' => 'Comment with custom foreign_key',
-				'foreign_key' => 2, // Override default modelId
+				'content' => 'Attempted cross-record IDOR',
+				'foreign_key' => 999,
 			],
-		];
-
-		$result = $this->Commentable->commentAdd(null, $options);
+		]);
 		$this->assertNotNull($result);
 
 		$comment = $this->getTableLocator()->get('Comments.Comments')->get($result);
-		$this->assertSame(2, $comment->foreign_key);
+		$this->assertSame(1, $comment->foreign_key, 'foreign_key in request data must NOT override modelId.');
 	}
 
 	/**

--- a/tests/TestCase/Model/Entity/CommentTest.php
+++ b/tests/TestCase/Model/Entity/CommentTest.php
@@ -13,56 +13,59 @@ use Comments\Model\Entity\Comment;
 class CommentTest extends TestCase {
 
 	/**
-	 * Test mass assignment protection for id field
+	 * Public-form fields are mass-assignable; everything else (id,
+	 * identity, relational, moderation flags) must be set explicitly via
+	 * `set()` / `patchEntity(..., accessibleFields: ...)`.
 	 *
 	 * @return void
 	 */
-	public function testIdNotMassAssignable(): void {
-		$comment = new Comment();
-		$comment->setAccess('id', false);
-
-		$comment = $comment->patch([
+	public function testOnlyPublicFieldsMassAssignable(): void {
+		$comment = new Comment([
 			'id' => 999,
+			'name' => 'John Doe',
+			'email' => 'john@example.com',
+			'title' => 'My Title',
 			'content' => 'Test comment',
 			'model' => 'Posts',
 			'foreign_key' => 1,
-		]);
+			'parent_id' => 5,
+			'user_id' => 42,
+			'is_private' => true,
+			'is_spam' => true,
+		], ['guard' => true]);
 
-		$this->assertNull($comment->id);
+		$this->assertNull($comment->id, 'id must never be mass-assignable.');
+		$this->assertSame('John Doe', $comment->name);
+		$this->assertSame('john@example.com', $comment->email);
+		$this->assertSame('My Title', $comment->title);
 		$this->assertSame('Test comment', $comment->content);
-		$this->assertSame('Posts', $comment->model);
-		$this->assertSame(1, $comment->foreign_key);
+
+		// Relational / identity / moderation columns must NOT be mass-assigned.
+		$this->assertNull($comment->model);
+		$this->assertNull($comment->foreign_key);
+		$this->assertNull($comment->parent_id);
+		$this->assertNull($comment->user_id);
+		$this->assertNull($comment->is_private);
+		$this->assertNull($comment->is_spam);
 	}
 
 	/**
-	 * Test all other fields are mass assignable
+	 * Server-trusted code can still set the protected columns explicitly
+	 * via `set()` or via an `accessibleFields` override on patchEntity.
 	 *
 	 * @return void
 	 */
-	public function testFieldsMassAssignable(): void {
-		$data = [
-			'content' => 'Test content',
-			'model' => 'Articles',
-			'foreign_key' => 123,
-			'parent_id' => 5,
-			'user_id' => 42,
-			'name' => 'John Doe',
-			'email' => 'john@example.com',
-			'is_private' => true,
-			'is_spam' => false,
-		];
+	public function testRelationalColumnsAssignableViaSet(): void {
+		$comment = new Comment();
+		$comment->set('model', 'Articles');
+		$comment->set('foreign_key', 123);
+		$comment->set('user_id', 42);
+		$comment->set('parent_id', 5);
 
-		$comment = new Comment($data);
-
-		$this->assertSame('Test content', $comment->content);
 		$this->assertSame('Articles', $comment->model);
 		$this->assertSame(123, $comment->foreign_key);
-		$this->assertSame(5, $comment->parent_id);
 		$this->assertSame(42, $comment->user_id);
-		$this->assertSame('John Doe', $comment->name);
-		$this->assertSame('john@example.com', $comment->email);
-		$this->assertTrue($comment->is_private);
-		$this->assertFalse($comment->is_spam);
+		$this->assertSame(5, $comment->parent_id);
 	}
 
 	/**
@@ -205,8 +208,16 @@ class CommentTest extends TestCase {
 
 		$this->assertFalse($comment->isAccessible('id'));
 		$this->assertTrue($comment->isAccessible('content'));
-		$this->assertTrue($comment->isAccessible('model'));
-		$this->assertTrue($comment->isAccessible('foreign_key'));
+		$this->assertTrue($comment->isAccessible('title'));
+		$this->assertTrue($comment->isAccessible('name'));
+		$this->assertTrue($comment->isAccessible('email'));
+
+		$this->assertFalse($comment->isAccessible('model'), 'Identity columns must not be mass-assignable.');
+		$this->assertFalse($comment->isAccessible('foreign_key'));
+		$this->assertFalse($comment->isAccessible('user_id'));
+		$this->assertFalse($comment->isAccessible('parent_id'));
+		$this->assertFalse($comment->isAccessible('is_private'));
+		$this->assertFalse($comment->isAccessible('is_spam'));
 	}
 
 }

--- a/tests/TestCase/Model/Table/CommentsTableTest.php
+++ b/tests/TestCase/Model/Table/CommentsTableTest.php
@@ -315,17 +315,18 @@ class CommentsTableTest extends TestCase {
 	 * @return void
 	 */
 	public function testBuildRulesParentIdExists(): void {
-		$data = [
+		// Identity columns + parent_id are not part of `_accessible`; the
+		// add() table method is the documented path for server-trusted
+		// fields, so it exercises the rules check at the right layer.
+		$result = $this->Comments->add([
 			'foreign_key' => 1,
 			'model' => 'Posts',
 			'content' => 'Test',
 			'parent_id' => 99999,
-		];
-		$entity = $this->Comments->newEntity($data);
-		$result = $this->Comments->save($entity);
+		]);
 
-		$this->assertFalse($result);
-		$this->assertArrayHasKey('parent_id', $entity->getErrors());
+		$this->assertTrue($result->isNew());
+		$this->assertArrayHasKey('parent_id', $result->getErrors());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The `Comment` entity allowed every column (except `id`) to be mass-assigned from request data via `_accessible = ['*' => true]`. Combined with `CommentableBehavior::commentAdd()` only setting `foreign_key` / `parent_id` from caller options *when not already present in data*, a public commenter could:

- Override `foreign_key` to attach a comment to **any** record (cross-record IDOR — attach a comment to anyone's article)
- Override `parent_id` to thread under any existing comment, bypassing the parent-validity check on the controller path
- Set `is_spam=false`, `user_id=N`, `is_private=true` from the request body

## Fix

**Entity allowlist (`Comment::_accessible`):** locked down to the four genuinely public form fields — `name`, `email`, `title`, `content`. Identity / relational columns (`user_id`, `model`, `foreign_key`, `parent_id`) and moderation flags (`is_private`, `is_spam`) must now be set server-side via `Entity::set()` or via the `add()` table method.

**`CommentableBehavior::commentAdd()`:** unconditionally writes `model`, `foreign_key`, and `parent_id` from the caller's `options` — the caller is authoritative, request data is not. The previous `if (!isset(...))` guards were exactly the IDOR pivot.

**`CommentsController::add()`:** explicitly nulls `parent_id` because the public add action doesn't support threading; otherwise a smuggled `parent_id` from the form could thread under an unrelated comment.

**`CommentsTable::add()`:** accepts `accessibleFields` for the four trusted columns inline (server-side callers explicitly set them; the entity's tight allowlist still blocks request-driven mass assignment). Switched from `saveOrFail()` to `save()` so rule-check errors (`parent_id` existsIn etc.) return the entity with errors instead of throwing.

## Also fixed

- Dead `Comment.approved` column references in `commentAdd()` — that column never existed in the migration and the query would throw on every fresh install (the threading branch via `$commentId` was effectively unreachable).
- Stale `Comment.id` / `Comment.foreign_key` table aliases in the parent-validity check — the real alias is `Comments`, so the check never matched and threading via the first arg was always broken.

## Tests

New regression coverage:
- `testOnlyPublicFieldsMassAssignable` — every non-public field stays `null` after mass assignment.
- `testRelationalColumnsAssignableViaSet` — server code can still set them.
- `testAccessible` — explicit positive + negative assertions on `_accessible`.
- `testCommentAddIgnoresParentIdInData` — smuggled `parent_id` in `options.data` is dropped; threading still works via the first arg.
- `testCommentAddIgnoresForeignKeyInData` — smuggled `foreign_key` is dropped; the comment lands on `modelId`.

Existing controller delete tests refactored to use a `makeComment()` helper that mimics server-trusted creation. All 95 tests pass; phpcs and phpstan are clean.